### PR TITLE
Fix default fragment float constants

### DIFF
--- a/Sources/SwiftyCreatives/Renderers/Base/RendererBase+StaticFunctions.swift
+++ b/Sources/SwiftyCreatives/Renderers/Base/RendererBase+StaticFunctions.swift
@@ -59,10 +59,10 @@ extension RendererBase {
         encoder.setVertexBuffer(DefaultBuffers.default_f4x4, offset: 0, index: VertexBufferIndex.CustomMatrix.rawValue)
         encoder.setVertexBuffer(DefaultBuffers.default_false, offset: 0, index: VertexBufferIndex.UseVertexColor.rawValue)
         encoder.setVertexBuffer(DefaultBuffers.default_f4, offset: 0, index: VertexBufferIndex.VertexColor.rawValue)
-        encoder.setFragmentBytes([1], length: Float.memorySize, index: FragmentBufferIndex.LightCount.rawValue)
+        encoder.setFragmentBytes([Float(1)], length: Float.memorySize, index: FragmentBufferIndex.LightCount.rawValue)
         encoder.setFragmentBuffer(DefaultBuffers.default_false, offset: 0, index: FragmentBufferIndex.HasTexture.rawValue)
         encoder.setFragmentBuffer(DefaultBuffers.default_false, offset: 0, index: FragmentBufferIndex.IsActiveToLight.rawValue)
-        encoder.setFragmentBytes([0], length: Float.memorySize, index: FragmentBufferIndex.FogDensity.rawValue)
+        encoder.setFragmentBytes([Float(0)], length: Float.memorySize, index: FragmentBufferIndex.FogDensity.rawValue)
         encoder.setFragmentBuffer(DefaultBuffers.default_f4, offset: 0, index: FragmentBufferIndex.FogColor.rawValue)
     }
 }


### PR DESCRIPTION
## Summary
- fix type mismatch when setting default fragment buffers

## Testing
- `swift test -l` *(fails: Failed to clone repository https://github.com/yukiny0811/FontVertexBuilder)*